### PR TITLE
mr_th_nb.c: fix warning

### DIFF
--- a/benchmarks/message_rate/mr_th_nb.c
+++ b/benchmarks/message_rate/mr_th_nb.c
@@ -149,7 +149,7 @@ void pre_scan_args(int argc, char **argv)
     }
 }
 
-int process_args(int argc, char **argv)
+void process_args(int argc, char **argv)
 {
     int c, rank;
 


### PR DESCRIPTION
This function doesn't return anything, so make it actually be void.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@artpol84 @thananon